### PR TITLE
Use exclusion comments

### DIFF
--- a/R/2dii_colours.R
+++ b/R/2dii_colours.R
@@ -71,7 +71,7 @@ r2dii_palette_colours <- function() {
 #' @export
 #' @examples
 #' r2dii_sector_colours()
-r2dii_sector_colours <- function() {
+r2dii_sector_colours <- function() { # nocov start
   # styler: off
   tribble(
         ~label, ~colour_hex,
@@ -85,4 +85,4 @@ r2dii_sector_colours <- function() {
        "steel",   "#a63d57"
   )
   # styler: on
-}
+}  # nocov end


### PR DESCRIPTION
Closes #89

Exclude code which results in an artifact of low coverage.

The file R/2dii_colours.R is fully covered by tests:

![image](https://user-images.githubusercontent.com/5856545/115399924-4e998f00-a1ae-11eb-8c6a-a27cd99236c4.png)

I expected `covr::package_coverage()` to report 100% cover but instead it reports 79.25%. This is weird and maybe a bug in covr or devtools but we can go around it by [excluding the relevant chunk of code from the code coverage analysis.](https://github.com/r-lib/covr#exclusion-comments)