### PR TITLE
In plot_timeline(), order legend to match lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,15 +18,15 @@ Depends:
     R (>= 3.4)
 Imports: 
     dplyr,
+    forcats,
     ggplot2,
     ggpubr,
+    glue,
     lubridate,
     magrittr,
     r2dii.data,
     rlang,
-    scales,
-    ggpubr,
-    glue
+    scales
 Suggests: 
     covr,
     r2dii.analysis,

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -48,21 +48,20 @@
 plot_timeline <- function(data, specs = timeline_specs(data)) {
   check_specs(specs, data)
 
+  data <- left_join(data, specs, by = "line_name")
+
   measured <- filter(data, !.data$extrapolated)
   plot <- ggplot() +
-    timeline_line(measured, specs) +
+    timeline_line(measured) +
     scale_x_date(expand = expansion(mult = c(0, 0.1))) +
     scale_y_continuous(expand = expansion(mult = c(0, 0.1))) +
     expand_limits(y = 0) +
-    scale_colour_manual(
-      values = specs$colour_hex,
-      labels = specs$label
-    )
+    scale_colour_manual(values = unique(data$colour_hex))
 
   if (any(data$extrapolated)) {
     extrapolated <- filter(data, .data$extrapolated)
     plot <- plot +
-      timeline_line(extrapolated, specs, linetype = .data$extrapolated) +
+      timeline_line(extrapolated, linetype = .data$extrapolated) +
       scale_linetype_manual(values = "dashed") +
       guides(linetype = FALSE)
   }
@@ -70,13 +69,15 @@ plot_timeline <- function(data, specs = timeline_specs(data)) {
   plot + theme_2dii()
 }
 
-timeline_line <- function(data, specs, ...) {
+timeline_line <- function(data, ...) {
+  data$label <- forcats::fct_reorder2(data$label, data$year, data$value)
+
   geom_line(
     data = data,
     aes(
       x = .data$year,
       y = .data$value,
-      colour = factor(.data$line_name, levels = specs$line_name),
+      colour = .data$label,
       ...
     )
   )

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -47,40 +47,24 @@
 #'   labs(title = "Emission intensity trend for Cement")
 plot_timeline <- function(data, specs = timeline_specs(data)) {
   check_specs(specs, data)
-
   data <- left_join(data, specs, by = "line_name")
 
-  measured <- filter(data, !.data$extrapolated)
-  plot <- ggplot() +
-    timeline_line(measured) +
+  ggplot() +
+    geom_line(
+      data = data, aes(
+        x = .data$year,
+        y = .data$value,
+        colour = forcats::fct_reorder2(.data$label, .data$year, .data$value),
+        linetype = .data$extrapolated
+      )) +
+    expand_limits(y = 0) +
     scale_x_date(expand = expansion(mult = c(0, 0.1))) +
     scale_y_continuous(expand = expansion(mult = c(0, 0.1))) +
-    expand_limits(y = 0) +
-    scale_colour_manual(values = unique(data$colour_hex))
-
-  if (any(data$extrapolated)) {
-    extrapolated <- filter(data, .data$extrapolated)
-    plot <- plot +
-      timeline_line(extrapolated, linetype = .data$extrapolated) +
-      scale_linetype_manual(values = "dashed") +
-      guides(linetype = FALSE)
-  }
-
-  plot + theme_2dii()
-}
-
-timeline_line <- function(data, ...) {
-  data$label <- forcats::fct_reorder2(data$label, data$year, data$value)
-
-  geom_line(
-    data = data,
-    aes(
-      x = .data$year,
-      y = .data$value,
-      colour = .data$label,
-      ...
-    )
-  )
+    scale_colour_manual(values = unique(data$colour_hex)) +
+    scale_linetype_manual(
+      values = if (any(data$extrapolated)) c("solid", "dashed") else "solid") +
+    guides(linetype = FALSE) +
+    theme_2dii()
 }
 
 check_specs <- function(specs, data) {

--- a/tests/testthat/_snaps/plot_timeline.md
+++ b/tests/testthat/_snaps/plot_timeline.md
@@ -10,7 +10,7 @@
       
       $layers
       $layers[[1]]
-      mapping: x = ~.data$year, y = ~.data$value, colour = ~factor(.data$line_name, levels = specs$line_name) 
+      mapping: x = ~.data$year, y = ~.data$value, colour = ~.data$label 
       geom_line: na.rm = FALSE, orientation = NA
       stat_identity: na.rm = FALSE
       position_identity 
@@ -22,7 +22,7 @@
       position_identity 
       
       $layers[[3]]
-      mapping: x = ~.data$year, y = ~.data$value, colour = ~factor(.data$line_name, levels = specs$line_name), linetype = ~.data$extrapolated 
+      mapping: x = ~.data$year, y = ~.data$value, colour = ~.data$label, linetype = ~.data$extrapolated 
       geom_line: na.rm = FALSE, orientation = NA
       stat_identity: na.rm = FALSE
       position_identity 
@@ -515,7 +515,7 @@
       [1] "value"
       
       $labels$colour
-      [1] "factor(line_name, levels = specs$line_name)"
+      [1] "label"
       
       $labels$linetype
       [1] "extrapolated"

--- a/tests/testthat/_snaps/plot_timeline.md
+++ b/tests/testthat/_snaps/plot_timeline.md
@@ -10,7 +10,7 @@
       
       $layers
       $layers[[1]]
-      mapping: x = ~.data$year, y = ~.data$value, colour = ~.data$label 
+      mapping: x = ~.data$year, y = ~.data$value, colour = ~forcats::fct_reorder2(.data$label, .data$year, .data$value), linetype = ~.data$extrapolated 
       geom_line: na.rm = FALSE, orientation = NA
       stat_identity: na.rm = FALSE
       position_identity 
@@ -18,12 +18,6 @@
       $layers[[2]]
       mapping: y = ~y 
       geom_blank: na.rm = FALSE
-      stat_identity: na.rm = FALSE
-      position_identity 
-      
-      $layers[[3]]
-      mapping: x = ~.data$year, y = ~.data$value, colour = ~.data$label, linetype = ~.data$extrapolated 
-      geom_line: na.rm = FALSE, orientation = NA
       stat_identity: na.rm = FALSE
       position_identity 
       
@@ -515,7 +509,7 @@
       [1] "value"
       
       $labels$colour
-      [1] "label"
+      [1] "forcats::fct_reorder2(label, year, value)"
       
       $labels$linetype
       [1] "extrapolated"


### PR DESCRIPTION
On master, the order of the legend does not match the order of the
plot lines: 

<img src=https://i.imgur.com/baQlmlW.png width=500>

Now they do

<img src=https://i.imgur.com/F8CauVj.png width=500>

This is the recommended approach to plotting lines and legends:
https://twitter.com/JennyBryan/status/1244499728831672320?s=20

With this change, I we may not need to ask the user to provide
the order, making the interfaces simpler.

While I'm here, I refactored to simplify the body of `plot_timeline()`. The
snapshot changed but as far as I can tell the result is as expected.

Example:

``` r
devtools::load_all()
#> ℹ Loading r2dii.plot.static

specs <- tibble::tribble(
                ~line_name,           ~label, ~colour_hex,
               "projected",          "Proj.",   "#1b324f",
       "corporate_economy",  "Corp. Economy",   "#00c082",
             "target_demo",         "Target",   "#ff9623",
  "adjusted_scenario_demo",  "Adj. Scenario",   "#d0d7e1"
)



data <- prepare_for_timeline(
  extrapolate_missing_values = TRUE,
  sda_target,
  sector_filter = "cement",
  year_start = 2020,
  year_end = 2050,
  column_line_names = "emission_factor_metric",
  value_to_plot = "emission_factor_value"
)
plot_timeline(data, specs = specs)
```

![](https://i.imgur.com/SLr1jfr.png)

``` r


data <- prepare_for_timeline(
  extrapolate_missing_values = FALSE,
  sda_target,
  sector_filter = "cement",
  year_start = 2020,
  year_end = 2050,
  column_line_names = "emission_factor_metric",
  value_to_plot = "emission_factor_value"
)
plot_timeline(data, specs = specs)
```

![](https://i.imgur.com/VSRs98G.png)

<sup>Created on 2021-05-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>